### PR TITLE
Add the ability the define inherited hooks.

### DIFF
--- a/lib/heredity.rb
+++ b/lib/heredity.rb
@@ -4,6 +4,33 @@ require "heredity/version"
 
 module Heredity
   def self.included(klass)
-    klass.__send__(:include, ::Heredity::InheritableClassInstanceVariables)
+    klass.class_eval do
+      extend ::Heredity::ClassMethods
+      include ::Heredity::InheritableClassInstanceVariables
+
+      class << self
+        alias_method :inheritance_eval, :on_inherit
+        alias_method :inherited_eval, :on_inherit
+        alias_method :when_inherited, :on_inherit
+      end
+    end
+  end
+
+  module ClassMethods
+    def _heredity_inherited_hooks
+      @_heredity_inherited_hooks ||= []
+    end
+
+    def inherited(klass)
+      super
+
+      _heredity_inherited_hooks.each do |block|
+        klass.class_eval(&block)
+      end
+    end
+
+    def on_inherit(&block)
+      _heredity_inherited_hooks << block
+    end
   end
 end

--- a/spec/heredity_spec.rb
+++ b/spec/heredity_spec.rb
@@ -10,4 +10,18 @@ describe Heredity do
       HeredityTestClass.should respond_to :inheritable_attributes
     end
   end
+
+  describe ".on_inherit" do
+    it "captures a block and eval's it when the class is inherited" do
+      HeredityTestClass.on_inherit do
+        def self.hello_world!
+        end
+      end
+
+      class Child < HeredityTestClass
+      end
+
+      Child.should respond_to(:hello_world!)
+    end
+  end
 end


### PR DESCRIPTION
Creating inheritance hooks that play well with others (e.g. don't clobber inheritance that are already defined) requires injecting inheritance hooks into the Class class (via extend). This works pretty well, but requires a lot of setup when typically, only a few lines need to be executed (i.e. eval'd) on the subclass.

To simplify this add, an `on_inherited` method that captures code and executes when the class is inherited.
