### PR TITLE
Use the new `:expect` syntax instead.

### DIFF
--- a/spec/heredity/inheritable_class_instance_variables_spec.rb
+++ b/spec/heredity/inheritable_class_instance_variables_spec.rb
@@ -30,41 +30,41 @@ describe Heredity::InheritableClassInstanceVariables do
 
   # API
   [TestInheritTop, TestSecondTier, TestThirdTier].each do |test_class|
-    specify { test_class.should respond_to(:inheritable_attributes) }
-    specify { test_class.should respond_to(:inheritable_attribute) }
-    specify { test_class.should respond_to(:class_inheritable_attributes) }
-    specify { test_class.should respond_to(:class_inheritable_attribute) }
+    specify { expect(test_class).to respond_to(:inheritable_attributes) }
+    specify { expect(test_class).to respond_to(:inheritable_attribute) }
+    specify { expect(test_class).to respond_to(:class_inheritable_attributes) }
+    specify { expect(test_class).to respond_to(:class_inheritable_attribute) }
   end
 
   context "when inheritable class instance variables is already included" do
     it "doesn't reset inheritable attributes" do
       TestInheritTop.__send__(:include, ::Heredity::InheritableClassInstanceVariables)
-      TestInheritTop.inheritable_attributes.should include :first, :awesomeness, :bestest
+      expect(TestInheritTop.inheritable_attributes).to include :first, :awesomeness, :bestest
     end
   end
 
   context "when overriding child class instance variables" do
     describe "single tier inheritance" do
       it "overrides the instance variables with the child defined values" do
-        TestEditSecondTier.first.should eq("Songs are for Singing")
-        TestEditSecondTier.awesomeness.should eq("Songs are for Singing" * 3)
-        TestEditSecondTier.bestest.should eq("SSSSSOOOOOOOOOONNNNNNNNGGGGGGGSSSSSS")
+        expect(TestEditSecondTier.first).to eq("Songs are for Singing")
+        expect(TestEditSecondTier.awesomeness).to eq("Songs are for Singing" * 3)
+        expect(TestEditSecondTier.bestest).to eq("SSSSSOOOOOOOOOONNNNNNNNGGGGGGGSSSSSS")
       end
     end
 
     describe "second tier inheritance" do
       it "overrides the instance variables with the child defined values" do
-        TestEditThirdTier.first.should eq([])
-        TestEditThirdTier.awesomeness.should eq([])
-        TestEditThirdTier.bestest.should eq([])
+        expect(TestEditThirdTier.first).to eq([])
+        expect(TestEditThirdTier.awesomeness).to eq([])
+        expect(TestEditThirdTier.bestest).to eq([])
       end
     end
 
     describe "second tier inheritance without changing first override" do
       it "keeps instance variables the same as first override" do
-        TestEditThirdTierWithoutEdit.first.should eq("Songs are for Singing")
-        TestEditThirdTierWithoutEdit.awesomeness.should eq("Songs are for Singing" * 3)
-        TestEditThirdTierWithoutEdit.bestest.should eq("SSSSSOOOOOOOOOONNNNNNNNGGGGGGGSSSSSS")
+        expect(TestEditThirdTierWithoutEdit.first).to eq("Songs are for Singing")
+        expect(TestEditThirdTierWithoutEdit.awesomeness).to eq("Songs are for Singing" * 3)
+        expect(TestEditThirdTierWithoutEdit.bestest).to eq("SSSSSOOOOOOOOOONNNNNNNNGGGGGGGSSSSSS")
       end
     end
   end
@@ -73,21 +73,21 @@ describe Heredity::InheritableClassInstanceVariables do
     describe "single tier inheritance" do
 
       it "creates public attr_readers for inherited attributes" do
-        TestSecondTier.should respond_to(:first)
-        TestSecondTier.should respond_to(:awesomeness)
-        TestSecondTier.should respond_to(:bestest)
+        expect(TestSecondTier).to respond_to(:first)
+        expect(TestSecondTier).to respond_to(:awesomeness)
+        expect(TestSecondTier).to respond_to(:bestest)
       end
 
       it "inherits the values of hashes" do
-        TestSecondTier.first.should eq({})
+        expect(TestSecondTier.first).to eq({})
       end
 
       it "inherits the values of arrays" do
-        TestSecondTier.awesomeness.should eq([:this, :that, :the_other])
+        expect(TestSecondTier.awesomeness).to eq([:this, :that, :the_other])
       end
 
       it "inherits the values of Objects" do
-        TestSecondTier.bestest.should eq("dirt apple (Po-ta-toes!)")
+        expect(TestSecondTier.bestest).to eq("dirt apple (Po-ta-toes!)")
       end
 
     end
@@ -95,21 +95,21 @@ describe Heredity::InheritableClassInstanceVariables do
     describe "2nd tier inheritance" do
 
       it "creates public attr_readers for inherited attributes" do
-        TestThirdTier.should respond_to(:first)
-        TestThirdTier.should respond_to(:awesomeness)
-        TestThirdTier.should respond_to(:bestest)
+        expect(TestThirdTier).to respond_to(:first)
+        expect(TestThirdTier).to respond_to(:awesomeness)
+        expect(TestThirdTier).to respond_to(:bestest)
       end
 
       it "inherits the values of hashes" do
-        TestThirdTier.first.should eq({})
+        expect(TestThirdTier.first).to eq({})
       end
 
       it "inherits the values of arrays" do
-        TestThirdTier.awesomeness.should eq([:this, :that, :the_other])
+        expect(TestThirdTier.awesomeness).to eq([:this, :that, :the_other])
       end
 
       it "inherits the values of Objects" do
-        TestThirdTier.bestest.should eq("dirt apple (Po-ta-toes!)")
+        expect(TestThirdTier.bestest).to eq("dirt apple (Po-ta-toes!)")
       end
 
     end


### PR DESCRIPTION
Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated.
